### PR TITLE
Support loading cookies from local machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,27 @@ Download all your kindle books script.
 
 1. 登陆 amazon.cn
 2. 访问 https://www.amazon.cn/hz/mycd/myx#/home/content/booksAll/dateDsc/
-3. 找到 cookie XHR 或者其他的方式
-4. 右键查看源码，搜索 `csrfToken` 复制后面的 value
-5. 执行 `python3 kindle.py  ${csrfToken} --is-cn --cookie {cookie}` 或 `python3 kindle.py  ${csrfToken} --is-cn --cookie-file {cookie file path}`
+3. 右键查看源码，搜索 `csrfToken` 复制后面的 value
+4. 执行 `python3 kindle.py ${csrfToken} --cn`
 
 # how to `amazon.com`
 1. login amazon.com
-2. visit https://www.amazon.com/hz/mycd/myx#/home/content/booksAll/dateDsc/ 
-3. find cookie F12 XHR or other ways
-4. right click this page source then find `csrfToken` value copy
-5. run: `python3 kindle.py ${csrfToken} --cookie {cookie}` or. `python3 kindle.py ${csrfToken} --cookie-file {cookie file path}`
+2. visit https://www.amazon.com/hz/mycd/myx#/home/content/booksAll/dateDsc/
+3. right click this page source then find `csrfToken` value copy
+4. run: `python3 kindle.py ${csrfToken}`
 
+# 手动输入 cookie
+
+若默认情况下提示 cookie 无效，你也可以手动输入 cookie 。方法是在上述全部书籍列表页面，按 <kbd>F12</kbd> 或右键点击——检查，进入控制台(Console)，输入 `document.cookie`，回车。复制输出的结果即可。
+
+然后，执行 `python3 kindle.py --cookie ${cookie} ${csrfToken}`。
+
+你也可以把 cookie 保存为文本文件，执行 `python3 kindle.py --cookie-file ${cookie_file} ${csrfToken}` 下载书籍。
 
 # 注意
-- cookie 和 csrf token 会过期，重新刷新下 amazon 的页面就行 
+- cookie 和 csrf token 会过期，重新刷新下 amazon 的页面就行
 - 书会下载在 DOWNLOADS 里
-- 如果你用 [DeDRM_tools](https://github.com/apprenticeharper/DeDRM_tools) 解密 key 存在 key.txt 里 
+- 如果你用 [DeDRM_tools](https://github.com/apprenticeharper/DeDRM_tools) 解密 key 存在 key.txt 里
 - 或者直接拖进 Calibre 里 please google it.
 - 如果过程中失败了可以使用 e.g. `--recover-index ${num}`
 - 如果出现名字太长的报错可以增加: `--cut-length 80` 来截断文件名

--- a/kindle.py
+++ b/kindle.py
@@ -37,9 +37,11 @@ KINDLE_URLS = {
 
 
 class Kindle:
-    def __init__(self, csrf_token, is_cn=True, out_dir=DEFAULT_OUT_DIR, cut_length=100):
+    def __init__(
+        self, csrf_token, domain="cn", out_dir=DEFAULT_OUT_DIR, cut_length=100
+    ):
         self.session = self.make_session()
-        self.urls = KINDLE_URLS["cn" if is_cn else "com"]
+        self.urls = KINDLE_URLS[domain]
         self.csrf_token = csrf_token
         self.total_to_download = 0
         self.out_dir = out_dir
@@ -199,9 +201,11 @@ if __name__ == "__main__":
         help="amazon or amazon cn cookie")
 
     parser.add_argument(
-        "--is-cn",
-        dest="is_cn",
-        action="store_true",
+        "--cn",
+        dest="domain",
+        action="store_const",
+        const="cn",
+        default="com",
         help="if your account is an amazon.cn account",
     )
     parser.add_argument(
@@ -237,7 +241,7 @@ if __name__ == "__main__":
     if not os.path.exists(options.outdir):
         os.makedirs(options.outdir)
     kindle = Kindle(
-        options.csrf_token, options.is_cn, options.outdir, options.cut_length
+        options.csrf_token, options.domain, options.outdir, options.cut_length
     )
     kindle.set_cookie_from_string(options.cookie)
     kindle.download_books(start_index=options.index)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests
+browsercookie @ git+https://github.com/richardpenman/browsercookie@master
+pywin32 ; sys_platform == 'win32'


### PR DESCRIPTION
- Introduce `browsercookie` to read cookies from Chrome or Firefox
- Rename the `--is-cn` option as `--cn` to accept more possible values