### PR TITLE
Escape windows filename

### DIFF
--- a/kindle.py
+++ b/kindle.py
@@ -148,7 +148,7 @@ class Kindle:
                 r"filename\*=UTF-8''(.+)", r.headers["Content-Disposition"]
             )[0]
             name = urllib.parse.unquote(name)
-            name = name.replace("/", "_")
+            name = re.sub(r'[\\/:*?"<>|]', '_', name)
             if len(name) > self.cut_length:
                 name = name[: self.cut_length - 5] + name[-5:]
             total_size = r.headers["Content-length"]


### PR DESCRIPTION
[The document said](https://docs.microsoft.com/en-us/windows/win32/msi/filename), filenames must not contain the following characters '\/:*?"<>|' in filename on windows, so replace those characters with '_'.