### PR TITLE
fix#56(KeyError: 'items')parameter passing error

### DIFF
--- a/kindle_download_helper.py
+++ b/kindle_download_helper.py
@@ -158,7 +158,7 @@ class KindleMainDialog(QtWidgets.QDialog):
         self.ui.fetchButton.setEnabled(False)
         filetype = self.get_filetype()
         try:
-            all_books = self.kindle.get_all_books(filetype)
+            all_books = self.kindle.get_all_books(filetype=filetype)
             book_data = [
                 [item["title"], item["authors"], item["asin"], filetype]
                 for item in all_books


### PR DESCRIPTION
`kindle_download_helper.py`line161 调用`get_all_books()`时, 只传递了后面的参数`filetype`, 值错位传到`start_index`上. 最后得到报错的JSON, 也就不存在`items`这个键值.

将此处改为关键字传参