### PR TITLE
feat: using title of metadata instead of response's title.

### DIFF
--- a/kindle.py
+++ b/kindle.py
@@ -459,6 +459,8 @@ class Kindle:
                 r"filename\*=UTF-8''(.+)", r.headers["Content-Disposition"]
             )[0]
             name = urllib.parse.unquote(name)
+            _, extname = os.path.splitext(name)
+            name = title + extname
             name = re.sub(r'[\\/:*?"<>|]', "_", name)
 
             ##### if you have many duplicate name books #####


### PR DESCRIPTION
I see [#70](https://github.com/yihong0618/Kindle_download_helper/pull/70#issue-1286610425).

> 有些第三方推送的书，文件名和 title 相差较大，修正为 title + 扩展名。大部分书籍不受影响。

So we can keep using title and replacing illegal symbol in the end.

#73 