### PR TITLE
Set the default value of --cut-length to a smaller value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ python3 kindle.py --cn --cookie ${cookie} ${csrfToken}
 - 如果你用 [DeDRM_tools](https://github.com/apprenticeharper/DeDRM_tools) 解密 key 存在 key.txt 里
 - 或者直接拖进 Calibre 里 please google it.
 - 如果过程中失败了可以使用 e.g. `--resume-from ${num}`
-- 如果出现名字太长的报错可以增加：`--cut-length 80` 来截断文件名
+- 如果出现名字太长的报错可以增加：`--cut-length 70` 来截断文件名
 - 支持推送文件下载 `--pdoc`
 - 如果有很多同名 pdoc 或 book 可以使用 `--resolve_duplicate_names` 解决同名冲突
 - error log 记录在 .error_books.log 中
@@ -221,7 +221,7 @@ python3 kindle.py --cn --cookie ${cookie} ${csrfToken}
 - If you use [DeDRM_tools](https://github.com/apprenticeharper/DeDRM_tools) to decrypt the key, it will be stored in key.txt
 - or just drag it into Calibre. Please google it.
 - If the process fails you can use e.g. `--resume-from ${num}`
-- If the name is too long, you can add: `-cut-length 80` to truncate the file name
+- If the name is too long, you can add: `-cut-length 70` to truncate the file name
 - Support push file download `--pdoc`
 - If there are many pdocs or books with the same name, you can use `--resolve_duplicate_names` to resolve conflicts with the same name.
 - error log is logged in .error_books.log

--- a/kindle_download_helper/kindle.py
+++ b/kindle_download_helper/kindle.py
@@ -59,7 +59,7 @@ class Kindle:
         out_dir=DEFAULT_OUT_DIR,
         out_dedrm_dir=DEFAULT_OUT_DEDRM_DIR,
         out_epub_dir=DEFAULT_OUT_EPUB_DIR,
-        cut_length=100,
+        cut_length=76,
         session_file=DEFAULT_SESSION_FILE,
         **kwargs,
     ):

--- a/kindle_download_helper/no_kindle.py
+++ b/kindle_download_helper/no_kindle.py
@@ -61,7 +61,7 @@ class NoKindle:
         out_dir=DEFAULT_OUT_DIR,
         out_dedrm_dir=DEFAULT_OUT_DEDRM_DIR,
         out_epub_dir=DEFAULT_OUT_EPUB_DIR,
-        cut_length=100,
+        cut_length=76,
     ):
         self.out_dir = out_dir
         self.out_dedrm_dir = out_dedrm_dir


### PR DESCRIPTION
I'm encountering a 'File name too long' issue when playing with kindle_download_helper. This patch sets the default value of --cut-length (from 100) to a smaller value (76).

Stack trace:

```
Book part successfully saved to DOWNLOADS/B07X8FKFVG_EBOK.mbpV2
Traceback (most recent call last):
  File "/home/v/x/gh/Kindle_download_helper/kindle_download_helper/no_cli.py", line 94, in no_main
    nk.download_book(e["ASIN"])
  File "/home/v/x/gh/Kindle_download_helper/kindle_download_helper/no_kindle.py", line 231, in download_book
    self._download_kfx(manifest, asin)
  File "/home/v/x/gh/Kindle_download_helper/kindle_download_helper/no_kindle.py", line 331, in _download_kfx
    with ZipFile(fn, "w") as myzip:
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/zipfile.py", line 1283, in __init__
    self.fp = io.open(file, filemode)
              ^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 36] File name too long: 'DOWNLOADS/82年生的金智英【豆瓣2019年最受欢迎图书！亚洲10年来少见的现象级畅销书。一个女孩要经历多少看不见的坎坷，才能跌撞地长大成人。韩国总统文在寅、
  民主持人刘在石、BTS团长南俊都_B07X8FKFVG_EBOK.kfx-zip'
[Errno 36] File name too long: 'DOWNLOADS/82年生的金智英【豆瓣2019年最受欢迎图书！亚洲10年来少见的现象级畅销书。一个女孩要经历多少看不见的坎坷，才能跌撞地长大成人。韩国总统文在寅、国民主持
  刘在石、BTS团长南俊都_B07X8FKFVG_EBOK.kfx-zip'
```

Can we have a smarter algorithm to truncate the file name?