### PR TITLE
added index into log message

### DIFF
--- a/kindle_download_helper/kindle.py
+++ b/kindle_download_helper/kindle.py
@@ -522,7 +522,7 @@ class Kindle:
                     pass
         except Exception as e:
             logger.error(str(e))
-            logger.error(f"Title: {title}, Asin: {asin} download failed")
+            logger.error(f"Index: {index + 1}, Title: {title}, Asin: {asin} download failed")
 
     def download_books(self, start_index=0, filetype="EBOK"):
         # use default device


### PR DESCRIPTION
I tried to download over 100 books and a few of them failed. I had to find those titles among the book list. I think adding index into the error log would make manual re-download easier.