### PR TITLE
fix `TypeError: string indices must be integers, not 'str'`  when `meta_data` contains only one book

### DIFF
--- a/kindle_download_helper/no_kindle.py
+++ b/kindle_download_helper/no_kindle.py
@@ -174,9 +174,12 @@ class NoKindle:
         library = xmltodict.parse(r.text)
         library = json.loads(json.dumps(library))
         library = library["response"]["add_update_list"]
-        ebooks = [i for i in library["meta_data"] if i["cde_contenttype"] == "EBOK"]
+        meta_data: dict | list = library["meta_data"]
+        if isinstance(meta_data, dict):
+            meta_data = [meta_data]
+        ebooks = [i for i in meta_data if i["cde_contenttype"] == "EBOK"]
         ebooks = [e for e in ebooks if self._is_ebook(e)]
-        pdocs = [i for i in library["meta_data"] if i["cde_contenttype"] == "PDOC"]
+        pdocs = [i for i in meta_data if i["cde_contenttype"] == "PDOC"]
         unknow_index = 1
 
         for i in ebooks + pdocs:

--- a/kindle_download_helper/no_kindle.py
+++ b/kindle_download_helper/no_kindle.py
@@ -174,19 +174,23 @@ class NoKindle:
         library = xmltodict.parse(r.text)
         library = json.loads(json.dumps(library))
         library = library["response"]["add_update_list"]
-        meta_data: dict | list = library["meta_data"]
+        meta_data = library["meta_data"]
         if isinstance(meta_data, dict):
             meta_data = [meta_data]
-        ebooks = [i for i in meta_data if i["cde_contenttype"] == "EBOK"]
-        ebooks = [e for e in ebooks if self._is_ebook(e)]
-        pdocs = [i for i in meta_data if i["cde_contenttype"] == "PDOC"]
-        unknow_index = 1
+        ebooks = []
+        pdocs = []
+        for i in meta_data:
+            if i["cde_contenttype"] == "EBOK" and self._is_ebook(i):
+                ebooks.append(i)
+            elif i["cde_contenttype"] == "PDOC":
+                pdocs.append(i)
+        unknown_index = 1
 
         for i in ebooks + pdocs:
             if isinstance(i["title"], dict):
                 if i["ASIN"] in self.ebook_library_dict:
-                    unknow_index += 1
-                book_title = i["title"].get("#text", str(unknow_index))
+                    unknown_index += 1
+                book_title = i["title"].get("#text", str(unknown_index))
             else:
                 book_title = i["title"]
             book_title = re.sub(


### PR DESCRIPTION
不知道是不是我只有一本书的原因，我在 `amazon.co.jp` 下用 `no_kindle.py` 下载时遇到了标题中的错误，打印看了一下 `library["meta_data"]` 本身就是个 `dict`, 但代码里是当 `list` 处理的。总之简单加了个分支处理了下这个特殊情况。