### PR TITLE
[doc] 增加单独执行 dedrm 的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,14 @@ python3 kindle.py --cn --cookie ${cookie} ${csrfToken}
 - 如果有很多同名 pdoc 或 book 可以使用 `--resolve_duplicate_names` 解决同名冲突
 - error log 记录在 .error_books.log 中
 - 支持生成最近读完书的 README `--readme` 生成的文件在 `my_kindle_stats.md` 中
-- 支持 mobi 类型的文件直接 dedrm `--dedrm` 生成的文件在 `DEDRMS` 里
+- 支持 mobi 类型的文件直接 dedrm `--dedrm` 生成的文件在 `DEDRMS` 里，默认同时输出 azw 和 epub 两种格式
+
+```
+pip install mobi
+
+# 其中后 3 个参数，仅在必要时指定
+python3 dedrm.py 源目录 目标目录 密钥 输出格式
+```
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ python3 kindle.py --cn --cookie ${cookie} ${csrfToken}
 - 如果有很多同名 pdoc 或 book 可以使用 `--resolve_duplicate_names` 解决同名冲突
 - error log 记录在 .error_books.log 中
 - 支持生成最近读完书的 README `--readme` 生成的文件在 `my_kindle_stats.md` 中
-- 支持 mobi 类型的文件直接 dedrm `--dedrm` 生成的文件在 `DEDRMS` 里，默认同时输出 azw 和 epub 两种格式
+- 支持 mobi 类型的文件直接 dedrm `--dedrm` 生成的文件在 `DEDRMS` 里
+- 脚本 `dedrm.py` 用于单独解密已下载的电子书文件，默认同时输出 azw 和 epub 两种格式
 
 ```
-pip install mobi
-
-# 其中后 3 个参数，仅在必要时指定
-python3 dedrm.py 源目录 目标目录 密钥 输出格式
+# 其中后 3 个参数，仅在必要时指定，用法 python3 dedrm.py 1源目录 2目标目录 3密钥 4输出格式
+#   例如对 ebook 中的文件解密，并只生成 epub 格式的 dedrm 文件
+$ python3 dedrm.py ebook DeDRMed key.txt中的密钥串 epub
 ```
 
 ## Note

--- a/dedrm.py
+++ b/dedrm.py
@@ -17,7 +17,7 @@ def read_key_from_file(directory):
         print(f"No key file found in {directory}. Proceeding without a key.")
     return None
 
-def process_azw_files(source_directory, output_directory='DeDRMed', device_serial_number=None):
+def process_azw_files(source_directory, output_directory='DeDRMed', device_serial_number=None, dump_azw=True, dump_epub=True):
     if device_serial_number is None:
         device_serial_number = read_key_from_file(source_directory)
         if device_serial_number is None:
@@ -33,6 +33,7 @@ def process_azw_files(source_directory, output_directory='DeDRMed', device_seria
 
     for filename in os.listdir(source_directory):
         if filename.endswith((".azw", ".azw3")):
+            print(f"Processed {filename}: ", end="")
             path = os.path.join(source_directory, filename)
             try:
                 out = path  # Original file path
@@ -46,6 +47,11 @@ def process_azw_files(source_directory, output_directory='DeDRMed', device_seria
                 totalpids = list(set(totalpids))
                 mb.make_drm_file(totalpids, out_dedrm)
                 time.sleep(1)
+
+                if dump_azw:
+                    print(f"DeDRMed file saved in {azw_output_dir} ")
+
+                if not dump_epub: continue
 
                 # Extract and determine if output is EPUB or HTML
                 epub_dir, output_file = extract(out_dedrm)
@@ -62,17 +68,31 @@ def process_azw_files(source_directory, output_directory='DeDRMed', device_seria
                 shutil.copy2(output_file, final_output_path)
                 shutil.rmtree(epub_dir)  # Clean up extraction directory
 
-                print(f"Processed {filename}: DeDRMed file saved in {azw_output_dir}, EPUB/HTML saved as {final_output_path}.")
+                print(f"EPUB/HTML saved as {final_output_path}.")
+                if not dump_azw:
+                    os.remove(out_dedrm)
             except Exception as e:
                 print(f"Error processing {filename}: {e}")
 
 if __name__ == "__main__":
+    cmd_usage = "Usage: script.py <source_directory> [output_directory] [device_serial_number] [specific_filetype(azw/epub)]"
     if len(sys.argv) < 2:
-        print("Usage: script.py <source_directory> [output_directory] [device_serial_number]")
+        print(cmd_usage)
         sys.exit(1)
 
     source_directory = sys.argv[1]
     output_directory = sys.argv[2] if len(sys.argv) > 2 else 'DeDRMed'
     device_serial_number = sys.argv[3] if len(sys.argv) > 3 else None
 
-    process_azw_files(source_directory, output_directory, device_serial_number)
+    dump_azw = True
+    dump_epub = True
+    if len(sys.argv) > 4:
+        if sys.argv[4] == 'azw':
+            dump_epub = False
+        elif sys.argv[4] == 'epub':
+            dump_azw = False
+        else:
+            print(cmd_usage)
+            sys.exit(1)
+
+    process_azw_files(source_directory, output_directory, device_serial_number, dump_azw, dump_epub)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 browser-cookie3
+mobi
 moki
 amazon.ion
 rich


### PR DESCRIPTION
1. 需单独 pip 安装的模块
2. 增加仅输出 azw 或 epub 格式的命令行参数选项