### PR TITLE
fix: handle potential KeyError

### DIFF
--- a/kindle_download_helper/kindle.py
+++ b/kindle_download_helper/kindle.py
@@ -334,7 +334,11 @@ class Kindle:
             if not result.get("success", True):
                 logger.error("get all books error: %s", result.get("error"))
                 break
-            items = result["OwnershipData"]["items"]
+            try:
+                items = result["OwnershipData"]["items"]
+            except KeyError:
+                logger.error("get all books error: %s", result.get("error"))
+                break
             for item in items:
                 if filetype == "PDOC":
                     item["title"] = html.unescape(item["title"])


### PR DESCRIPTION
### 问题概述

当下载大量个人文档时（如：~15000 份，之前有将微信文章推送到 Kindle 的习惯），有一定概率触发 `KeyError`。

与 https://github.com/yihong0618/Kindle_download_helper/issues/99 所述错误一致，但我在下载到第 5000~ 多份、8000~ 多份时就遇到了（BTW，我还没下载到第 10000 份 PDOC）。有时候多试几次这个错误就没有了，但更多的时候，是请求次数一多就会出现。

### 调查原因

对代码做了一些修改，以排查问题原因：

![屏幕截图 2024-06-17 234342](https://github.com/yihong0618/Kindle_download_helper/assets/5435649/e3b1deac-cfe3-4312-a707-9d96f9547352)

接下来测试一下！

<details>

<summary>控制台输出</summary>

```
(base) D:\GitHub\yihong0618\Kindle_download_helper>python .\kindle.py <此处略去 csrf token> --cookie-file cookie.txt --cn --pdoc --resume-from 8819
Amazon bot check detected, sleep 3 sec
Using default device serial Number: G090G10554960TGF
It will take some time to get all PDOC books list, please wait
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
Amazon bot check detected, sleep 5 sec and try this api again, now index: 9628/15040
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
Traceback (most recent call last):
  File "D:\GitHub\yihong0618\Kindle_download_helper\kindle.py", line 5, in <module>
    main()
  File "D:\GitHub\yihong0618\Kindle_download_helper\kindle_download_helper\cli.py", line 318, in main
    kindle.download_books(
  File "D:\GitHub\yihong0618\Kindle_download_helper\kindle_download_helper\kindle.py", line 534, in download_books
    books = self.get_all_books(filetype=filetype, start_index=start_index)
  File "D:\GitHub\yihong0618\Kindle_download_helper\kindle_download_helper\kindle.py", line 338, in get_all_books
    items = result["OwnershipData"]["items"]
KeyError: 'items'

(base) D:\GitHub\yihong0618\Kindle_download_helper>python .\kindle.py <此处略去 csrf token> --cookie-file cookie.txt --cn --pdoc --resume-from 8819
Amazon bot check detected, sleep 3 sec
Using default device serial Number: G090G10554960TGF
It will take some time to get all PDOC books list, please wait
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
Amazon bot check detected, sleep 5 sec and try this api again, now index: 9088/15040
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
<Response [200]> <class 'requests.models.Response'> application/json;charset=UTF-8
{"OwnershipData":{"success":false,"error":"GENERIC_ERROR"}}
Traceback (most recent call last):
  File "D:\GitHub\yihong0618\Kindle_download_helper\kindle.py", line 5, in <module>
    main()
  File "D:\GitHub\yihong0618\Kindle_download_helper\kindle_download_helper\cli.py", line 318, in main
    kindle.download_books(
  File "D:\GitHub\yihong0618\Kindle_download_helper\kindle_download_helper\kindle.py", line 538, in download_books
    books = self.get_all_books(filetype=filetype, start_index=start_index)
  File "D:\GitHub\yihong0618\Kindle_download_helper\kindle_download_helper\kindle.py", line 339, in get_all_books
    items = result["OwnershipData"]["items"]
KeyError: 'items
```
</details>

可以看到，两次连续测试都触发了 KeyError。其中，第二次是添加了一些测试语句后的输出，对应的 JSON 为：

```json
{"OwnershipData":{"success":false,"error":"GENERIC_ERROR"}}
```

### 解决思路

##### 思路一（本 PR）

忽略 KeyError，并继续执行。下次再 resume-from 即可。经测试，忽略该错误可继续下载。

##### 思路二

调整此行：

https://github.com/yihong0618/Kindle_download_helper/blob/7d8a3abd5cf778e5e3a6a4e1c77c8a6157a21ceb/kindle_download_helper/kindle.py#L334

```diff
diff --git a/kindle_download_helper/kindle.py b/kindle_download_helper/kindle.py
index 14d7924..fcdbf2b 100644
--- a/kindle_download_helper/kindle.py
+++ b/kindle_download_helper/kindle.py
@@ -331,7 +331,7 @@ class Kindle:
                             )
                         break
             result = r.json()
-            if not result.get("success", True):
+            if not result.get("success", False):
                 logger.error("get all books error: %s", result.get("error"))
                 break
             try:
```

但不知道这里 @yihong0618 是不是有意用 `True` 的，因此我没有贸然这样改。

如果这样改更合适，我可以更新一下！

谢谢 @yihong0618 ！终于可以把个人文档下载下来了。



